### PR TITLE
fix: subpath-safe assets, PWA install, a11y/SEO/CSP, and CI link checks

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,21 @@
+name: Link Checker
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lychee:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Scan links with lychee
+        uses: lycheeverse/lychee-action@v1
+        with:
+          args: --base . --accept '200..299,403' --verbose ./
+          fail: true

--- a/404.html
+++ b/404.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>Page Not Found · AdTok</title>
+  <style>
+    :root {
+      font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #f5f1eb;
+      color: #2c1810;
+    }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      padding: 2rem;
+    }
+    main {
+      max-width: 32rem;
+      background: #ffffff;
+      padding: 2.5rem;
+      border-radius: 1.5rem;
+      box-shadow: 0 18px 48px rgba(212,117,107,.2);
+      text-align: center;
+    }
+    h1 {
+      margin-top: 0;
+      font-size: 2rem;
+    }
+    a {
+      display: inline-block;
+      margin-top: 1.5rem;
+      padding: 0.75rem 1.5rem;
+      background: #d4756b;
+      color: #ffffff;
+      text-decoration: none;
+      border-radius: 999px;
+      font-weight: 600;
+    }
+    a:focus-visible {
+      outline: 3px solid #1a73e8;
+      outline-offset: 3px;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>We couldn’t find that page</h1>
+    <p>The link you followed may be broken or the page may have been moved. Use the button below to return to the AdTok manual.</p>
+    <a href="/AdTok/">Back to AdTok home</a>
+  </main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -7,14 +7,24 @@
   <meta property="og:title" content="TikTok Growth Master Manual"/>
   <meta property="og:description" content="App-style manual with TikTok marketing strategies, analytics, and 30-day execution plan."/>
   <meta property="og:type" content="website"/>
+  <link rel="canonical" href="https://senpai-sama7.github.io/AdTok/"/>
+  <meta property="og:url" content="https://senpai-sama7.github.io/AdTok/"/>
+  <meta property="og:image" content="https://senpai-sama7.github.io/assets/images/adtok-og.jpg"/>
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="TikTok Growth Master Manual"/>
+  <meta name="twitter:description" content="App-style manual with TikTok marketing strategies, analytics, and 30-day execution plan."/>
+  <meta name="twitter:image" content="https://senpai-sama7.github.io/assets/images/adtok-og.jpg"/>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data:; media-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'nonce-adtok-base'; connect-src 'self'"/>
+  <link rel="manifest" href="manifest.webmanifest"/>
   <title>TikTok Growth Master Manual</title>
   <script type="module" src="/src/main.js"></script>
 </head>
 <body>
+<a class="skip-link" href="#main">Skip to content</a>
 <div class="shell">
   <aside class="side" role="navigation" aria-label="Main navigation">
     <div class="brand">
-      <img src="/assets/images/adtok-logo-3d.png" alt="AdTok logo" class="brand__img" decoding="async" loading="lazy"/>
+      <img id="logo" src="assets/images/adtok-logo-3d.png" alt="AdTok 3D wordmark" class="brand__img" decoding="async" width="160" height="160"/>
       <span class="brand__title">TikTok Growth Master Manual</span>
     </div>
     <nav class="nav" role="tablist" aria-label="Manual sections">
@@ -26,11 +36,11 @@
       <button id="tab-strategy" type="button" data-tab="strategy" role="tab" aria-selected="false" aria-controls="strategy" tabindex="-1">Strategy</button>
     </nav>
   </aside>
-  <main class="main" role="main">
+  <main id="main" class="main" role="main">
     <div class="hdr">
       <div class="hdr__content">
         <div class="hdr__badge">
-          <img src="/assets/images/adtok-logo-mobile.jpg" alt="TikTok Growth Master Manual mobile preview" class="hdr__image" decoding="async" loading="lazy"/>
+          <img id="mobilePreview" src="assets/images/adtok-logo-mobile.jpg" alt="AdTok mobile preview interface" class="hdr__image" decoding="async" loading="lazy" width="240" height="240"/>
           <div>
             <strong class="hdr__title">TikTok Growth Master Manual</strong>
             <span class="hdr__subtitle muted">App‑style manual</span>
@@ -69,13 +79,13 @@
               <iframe class="embed-frame" src="https://wirehaired-tail-7ea.notion.site/ebd/278a0505e282808cb012c5adf5e7df03" title="TikTok Growth Master Manual in Notion" loading="lazy" referrerpolicy="no-referrer"></iframe>
             </div>
           </div>
-          <p class="muted">Prefer opening in a new tab? Explore the <a href="https://www.perplexity.ai/page/tiktok-growth-master-manual-.DYHZWovTbq0WLwwVCIBog#0" target="_blank" rel="noopener">Perplexity research brief</a> or the <a href="https://wirehaired-tail-7ea.notion.site/ebd/278a0505e282808cb012c5adf5e7df03" target="_blank" rel="noopener">Notion execution workspace</a>.</p>
+          <p class="muted">Prefer opening in a new tab? Explore the <a href="https://www.perplexity.ai/page/tiktok-growth-master-manual-.DYHZWovTbq0WLwwVCIBog#0" target="_blank" rel="noopener noreferrer">Perplexity research brief</a> or the <a href="https://wirehaired-tail-7ea.notion.site/ebd/278a0505e282808cb012c5adf5e7df03" target="_blank" rel="noopener noreferrer">Notion execution workspace</a>.</p>
         </div>
         <div class="card s12 manual-audio"><div class="title">Audio Companion — TikTok Algorithm Secrets</div>
           <p class="muted">Listen to the narrated breakdown of hooks, SEO structure, and 2025 creator playbook highlights while you work through the manual.</p>
-          <audio controls preload="metadata" class="manual-audio__player">
-            <source src="/assets/audio/TikTok Algorithm Secrets Revealed_ Hooks, SEO, and the 2025 Creator Growth Manual.mp3" type="audio/mpeg"/>
-            Your browser does not support the audio element. <a href="/assets/audio/TikTok%20Algorithm%20Secrets%20Revealed_%20Hooks,%20SEO,%20and%20the%202025%20Creator%20Growth%20Manual.mp3">Download the audio guide</a>.
+          <audio id="audioSrc" controls preload="metadata" class="manual-audio__player">
+            <source src="assets/audio/tiktok-algorithm-secrets.mp3" type="audio/mpeg"/>
+            Your browser does not support the audio element. <a id="audioDownload" href="assets/audio/tiktok-algorithm-secrets.mp3" rel="noopener noreferrer">Download the audio guide</a>.
           </audio>
         </div>
       </div>
@@ -177,5 +187,42 @@
 
   </main>
 </div>
+<script nonce="adtok-base">
+  (function () {
+    const isSubpath = window.location.pathname.includes('/AdTok/');
+    const originBase = isSubpath ? 'https://senpai-sama7.github.io/' : './';
+    const assetBase = isSubpath ? originBase + 'AdTok/' : originBase;
+    const manifestEl = document.querySelector('link[rel="manifest"]');
+    if (manifestEl) {
+      manifestEl.setAttribute('href', (isSubpath ? '/AdTok/' : './') + 'manifest.webmanifest');
+    }
+    const assignments = [
+      { id: 'logo', attr: 'src', path: 'assets/images/adtok-logo-3d.png' },
+      { id: 'mobilePreview', attr: 'src', path: 'assets/images/adtok-logo-mobile.jpg' },
+      { id: 'audioSrc', attr: 'src', path: 'assets/audio/tiktok-algorithm-secrets.mp3' },
+      { id: 'audioDownload', attr: 'href', path: 'assets/audio/tiktok-algorithm-secrets.mp3' }
+    ];
+    assignments.forEach(({ id, attr, path }) => {
+      const node = document.getElementById(id);
+      if (node) {
+        node.setAttribute(attr, assetBase + path);
+      }
+    });
+    const audioDownload = document.getElementById('audioDownload');
+    if (audioDownload) {
+      audioDownload.setAttribute('download', 'tiktok-algorithm-secrets.mp3');
+    }
+    document.documentElement.style.setProperty(
+      '--hero-background-image',
+      `url(${assetBase}assets/images/adtok-logo-wave.jpg)`
+    );
+    if ('serviceWorker' in navigator) {
+      const swPath = isSubpath ? '/AdTok/sw.js' : '/sw.js';
+      navigator.serviceWorker.register(swPath).catch((err) => {
+        console.error('Service worker registration failed', err);
+      });
+    }
+  })();
+</script>
 </body>
 </html>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,22 @@
+{
+  "name": "AdTok Growth Manual",
+  "short_name": "AdTok",
+  "description": "TikTok Growth Master Manual — High-impact playbook for TikTok content creation, SEO, monetization, and growth.",
+  "start_url": "/AdTok/index.html",
+  "scope": "/AdTok/",
+  "display": "standalone",
+  "background_color": "#f5f1eb",
+  "theme_color": "#d4756b",
+  "icons": [
+    {
+      "src": "assets/icons/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "assets/icons/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://senpai-sama7.github.io/AdTok/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://senpai-sama7.github.io/AdTok/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,3 +1,41 @@
+/* Accessibility & performance guardrails */
+:root {
+  color-scheme: light;
+  scroll-behavior: smooth;
+  --focus-ring-color: #1a73e8;
+  --sidebar-width: 17.5rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+.skip-link {
+  position: absolute;
+  top: -4rem;
+  left: 1rem;
+  padding: 0.75rem 1.25rem;
+  background: var(--panel, #ffffff);
+  color: var(--ink, #2c1810);
+  font-weight: 600;
+  border-radius: 999px;
+  box-shadow: var(--clay-shadow, 0 8px 32px rgba(212,117,107,.15));
+  transition: top 0.2s ease;
+  z-index: 1000;
+}
+
+.skip-link:focus-visible {
+  top: 1rem;
+  outline: 3px solid var(--focus-ring-color);
+}
+
 /* AdTok - Modern Clay Skeuomorphic Dashboard */
 
 :root {
@@ -40,7 +78,7 @@ body {
 
 .shell {
   display: grid;
-  grid-template-columns: 280px 1fr;
+  grid-template-columns: var(--sidebar-width) 1fr;
   min-height: 100%;
 }
 
@@ -48,6 +86,7 @@ body {
   position: sticky;
   top: 0;
   height: 100vh;
+  width: var(--sidebar-width);
   padding: 24px;
   background: rgba(255,255,255,.95);
   backdrop-filter: blur(20px);
@@ -135,7 +174,7 @@ body {
   content: '';
   position: absolute;
   inset: 0;
-  background: url('/assets/images/adtok-logo-wave.jpg') center/cover no-repeat;
+  background: var(--hero-background-image, none) center/cover no-repeat;
   opacity: 0.18;
 }
 
@@ -507,7 +546,7 @@ canvas {
   }
 
   .hdr::before {
-    background-image: url('/assets/images/adtok-logo-mobile.jpg');
+    background: var(--hero-background-image, none) center/cover no-repeat;
     opacity: 0.22;
   }
 
@@ -534,20 +573,11 @@ canvas {
   }
 }
 
-/* Accessibility */
-@media (prefers-reduced-motion: reduce) {
-  * {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
-  }
-}
-
 /* Focus styles */
 button:focus-visible,
 .nav button:focus-visible {
-  outline: 2px solid var(--brand);
-  outline-offset: 2px;
+  outline: 3px solid var(--focus-ring-color);
+  outline-offset: 3px;
 }
 
 /* High contrast mode */

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,98 @@
+const STATIC_CACHE = 'adtok-static-v1';
+const DOCS_CACHE = 'adtok-docs-v1';
+const STATIC_ASSETS = [
+  './',
+  './index.html',
+  './manifest.webmanifest',
+  './src/main.js',
+  './src/tabs.js',
+  './src/charts.js',
+  './src/styles/main.css',
+  './assets/images/adtok-logo-3d.png',
+  './assets/images/adtok-logo-mobile.jpg',
+  './assets/icons/icon-192.png',
+  './assets/icons/icon-512.png',
+  './assets/audio/tiktok-algorithm-secrets.mp3'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    (async () => {
+      const cache = await caches.open(STATIC_CACHE);
+      await Promise.allSettled(
+        STATIC_ASSETS.map((asset) => cache.add(new Request(asset, { cache: 'reload' })))
+      );
+      await self.skipWaiting();
+    })()
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      const keys = await caches.keys();
+      await Promise.all(
+        keys
+          .filter((key) => key !== STATIC_CACHE && key !== DOCS_CACHE)
+          .map((key) => caches.delete(key))
+      );
+      await self.clients.claim();
+    })()
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  const requestURL = new URL(event.request.url);
+  if (requestURL.origin !== self.location.origin) {
+    return;
+  }
+
+  if (event.request.destination === 'document') {
+    event.respondWith(networkFirst(event.request));
+    return;
+  }
+
+  if (
+    ['style', 'script', 'image', 'font', 'audio', 'manifest'].includes(event.request.destination) ||
+    STATIC_ASSETS.some((asset) => requestURL.pathname.endsWith(asset.replace('./', '/')))
+  ) {
+    event.respondWith(cacheFirst(event.request));
+  }
+});
+
+async function cacheFirst(request) {
+  const cache = await caches.open(STATIC_CACHE);
+  const cached = await cache.match(request, { ignoreSearch: true });
+  if (cached) {
+    return cached;
+  }
+
+  const response = await fetch(request);
+  cache.put(request, response.clone());
+  return response;
+}
+
+async function networkFirst(request) {
+  const cache = await caches.open(DOCS_CACHE);
+  try {
+    const response = await fetch(request);
+    cache.put(request, response.clone());
+    return response;
+  } catch (error) {
+    const cached = await cache.match(request, { ignoreSearch: true });
+    if (cached) {
+      return cached;
+    }
+    return caches.match('./index.html');
+  }
+}
+
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});


### PR DESCRIPTION
## Summary
- harden AdTok landing page for GitHub Pages subpath deployments with canonical SEO, CSP, skip-link, and dynamic asset base handling
- add PWA support via updated manifest and new service worker that precaches static assets while keeping docs network-first
- supply operational assets (robots, sitemap, 404) and enforce automated link verification in CI

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d471ce1f54832084ad5f46a7a11187